### PR TITLE
fix: update Dockerfile to install corepack before enabling pnpm

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM node:18-alpine AS base
 RUN apk add --no-cache libc6-compat
+RUN npm install -g corepack@latest
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
 # Install dependencies only when needed


### PR DESCRIPTION
Docker build fails when running:
```
RUN corepack enable && corepack prepare pnpm@latest --activate
```
With the following error
```
 > [base 3/3] RUN corepack enable && corepack prepare pnpm@latest --activate:                                                                                                                  
2.014 Preparing pnpm@latest for immediate activation...                                                                                                                                        
3.017 Internal Error: Cannot find matching keyid: {"signatures":[{"sig":"MEYCIQDbcyRXEEpUvMj22WsicmOsvx+ctqHZv1vLScf3/247EAIhANfMkRDNAHdtTDNZ34BVH2z2z0Ef8o5VK4osH6ES9RHW","keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U"}],"keys":[{"expires":null,"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="}]}       
```

Possible causes:
* Older Corepack versions (before 0.31.0) don’t have these keys, causing signature verification failures.

This issue causes backend service fails to build, preventing the container from running.
This fix is only applied inside the Docker container, ensuring compatibility with Alpine Linux.

Fix was made based on this:
https://vercel.com/guides/corepack-errors-github-actions