### PR TITLE
Restrict File Upload Limit to Channel Creator & Real-Time File Upload

### DIFF
--- a/backend/models/Channel.js
+++ b/backend/models/Channel.js
@@ -10,6 +10,10 @@ const channelSchema = new mongoose.Schema(
       ref: "User",
       required: false,
     },
+    fileUpLoadLimit: {
+      type: Number,
+      default: 5 * 1024, // Default: 5KB, displays in bytes
+    },
   },
   { timestamps: true },
 );

--- a/backend/server.js
+++ b/backend/server.js
@@ -863,6 +863,7 @@ app.put("/api/:channelId/update-file-limit", async (req, res) => {
 
     await channel.save();
     console.log("saved new limit: ", channel.fileUpLoadLimit);
+    io.to(channelId).emit("file_limit_updated", { fileUploadLimit });
 
     res.json({ message: "File upload limit updated", fileUploadLimit });
   } catch (error) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,6 +15,7 @@ import { GridFsStorage } from "multer-gridfs-storage";
 import { GridFSBucket, ObjectId } from "mongodb";
 
 const app = express();
+const MAXLIMIT_FILE_UPLOAD = 100; // 100KB system limit
 
 app.use(cors());
 app.use(express.json());
@@ -617,6 +618,27 @@ app.post("/api/upload", upload.single("file"), async (req, res) => {
       .status(400)
       .json({ error: "Missing required fields: channelId or senderId" });
   }
+  // Check if within channel's file upload limit
+  const channel = await Channel.findById(channelId);
+  if (!channel) {
+    return res.status(401).json({ error: "Channel not found" });
+  }
+
+  console.log("Channel info: ", channel);
+  // Get the file upload limit (default 5MB if not set)
+  const fileUploadLimit_config = channel.fileUpLoadLimit || 5 * 1024; // Default 5KB in bytes
+  console.log(
+    `current limit of channel ${channelId}: `,
+    fileUploadLimit_config,
+  );
+
+  // Check if file size exceeds the channel's limit
+  if (req.file.size > fileUploadLimit_config) {
+    console.log("Requested file larger than limit");
+    return res.status(402).json({
+      error: `File exceeds the size limit of ${fileUploadLimit_config} KB`,
+    });
+  }
 
   try {
     const fileId = req.file.id;
@@ -797,5 +819,74 @@ app.put("/api/users/:userId/status", async (req, res) => {
     res.status(200).json({ message: "Status updated successfully", user });
   } catch (error) {
     res.status(500).json({ message: "Server error", error: error.message });
+  }
+});
+
+// Handle check if user is channel owner
+app.post("/api/channels/:channelId/is-owner", async (req, res) => {
+  try {
+    const { channelId } = req.params;
+    const userId = req.body.userId;
+
+    const channel = await Channel.findById(channelId);
+    if (!channel) return res.status(404).json({ error: "Channel not found" });
+
+    const isOwner = channel.createdBy?.toString() === userId;
+    return res.json({ isOwner });
+  } catch (error) {
+    console.error("Error checking ownership:", error);
+    return res.status(500).json({ error: "Server error" });
+  }
+});
+
+app.put("/api/:channelId/update-file-limit", async (req, res) => {
+  const { channelId } = req.params;
+  let { fileUploadLimit } = req.body;
+
+  try {
+    // Check if the channel exists
+    const channel = await Channel.findById(channelId);
+    if (!channel) {
+      return res.status(401).json({ message: "Channel not found" });
+    }
+
+    // Validate the new file limit
+    console.log(`Request change file limit to: ${fileUploadLimit} KB`);
+    if (fileUploadLimit <= 0 || fileUploadLimit > MAXLIMIT_FILE_UPLOAD) {
+      return res
+        .status(402)
+        .json({ message: "<System>: Invalid file size limit 100KB" });
+    }
+
+    // Update the file upload limit
+    channel.fileUpLoadLimit = fileUploadLimit * 1024; //in bytes
+
+    await channel.save();
+    console.log("saved new limit: ", channel.fileUpLoadLimit);
+
+    res.json({ message: "File upload limit updated", fileUploadLimit });
+  } catch (error) {
+    console.error("Error updating file limit:", error);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+app.get("/api/:channelId/get-file-limit", async (req, res) => {
+  const { channelId } = req.params;
+
+  try {
+    // Check if the channel exists
+    const channel = await Channel.findById(channelId);
+    if (!channel) {
+      return res.status(404).json({ message: "Channel not found" });
+    }
+
+    // Get the file upload limit
+    const channel_fileUploadLimit = channel.fileUpLoadLimit;
+
+    res.json({ fileUpLoadLimit: channel_fileUploadLimit });
+  } catch (error) {
+    console.error("Error updating file limit:", error);
+    res.status(500).json({ message: "Server error" });
   }
 });

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -218,7 +218,7 @@ export default function Chat({
     return () => {
       socket?.off("file_uploaded", handleFileUpload);
     };
-  }, [currentChannelId]);
+  }, [currentChannelId, socket]);
 
   const onClick = async () => {
     if (!user || !currentChannelId || message.trim() === "") return;

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -182,7 +182,23 @@ export default function Chat({
         body: formData,
       });
 
-      if (!response.ok) throw new Error("File upload failed");
+      const data = await response.json();
+      if (!response.ok) {
+        if (response.status === 401) {
+          alert("Error: Channel not found.");
+        } else if (response.status === 402) {
+          alert(
+            `Error: Invalid file size limit, current file size: ${
+              file.size / 1024
+            } KB.`,
+          );
+        } else if (response.status === 500) {
+          alert("Error: Server error. Please try again later.");
+        } else {
+          alert(`Unexpected error: ${data.message || "Unknown error"}`);
+        }
+        return;
+      }
 
       console.log("Log: File uploaded successfully");
     } catch (error) {
@@ -579,6 +595,7 @@ export default function Chat({
             channelId={currentChannelId}
             files={files}
             API_BASE_URL={API_BASE_URL}
+            current_userID={user.userID}
           />
         )}
       </div>

--- a/frontend/components/ui/chatInfo.tsx
+++ b/frontend/components/ui/chatInfo.tsx
@@ -108,9 +108,16 @@ const ChatInfo: React.FC<ChatInfoProps> = ({
       },
     );
 
+    // Listen for real-time file upload limit updates
+    socket.on("file_limit_updated", ({ fileUploadLimit }) => {
+      console.log("File limit updated in real-time:", fileUploadLimit);
+      setFileSizeLimit(fileUploadLimit);
+    });
+
     return () => {
       socket.off("channel_participants");
       socket.off("statusUpdated");
+      socket.off("file_limit_updated");
     };
   }, [socket, channelId]);
 
@@ -132,6 +139,7 @@ const ChatInfo: React.FC<ChatInfoProps> = ({
     }
     console.log("Frontend receive file limit: ", fileSizeLimit);
     try {
+      setFileSizeLimit(fileSizeLimit);
       const response = await fetch(
         `${API_BASE_URL}/api/${channelId}/update-file-limit`,
         {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "bcryptjs": "^2.4.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "emoji-mart": "^5.6.0",
         "lucide-react": "^0.473.0",
         "mongoose": "^8.10.0",
         "multer": "^1.4.5-lts.1",
@@ -2446,8 +2447,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
       "integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",


### PR DESCRIPTION
This PR introduces that only the channel creator can set the file upload limit. Additionally, it ensures that file uploads are updated in real-time across all users in the channel by properly handling WebSocket events.


Changes Made
### 1. Restrict File Upload Limit to Channel Creator
Updated backend (PUT /api/:channelId/update-file-limit) to check if the current user is the channel creator before allowing file upload limit updates.
Frontend (ChatInfo.tsx):
Fetches isOwner when loading the channel.
Disables the file limit input for non-creators.
Shows a tooltip warning when hovering over the disabled input.
### 2. Fix Real-Time File Upload Updates
Backend

Emits "file_uploaded" event after successful upload.
Emits "message" event to notify the chat about a new file upload.
Frontend (Chat.tsx & ChatInfo.tsx)

Listens for "file_uploaded" events and updates file list instantly.
Listens for "message" events and appends new messages.
### 3 Ensure Files Persist After Refresh
Fetches latest files when the channel is mounted (useEffect on channelId).